### PR TITLE
[fix] 제목 null 이슈 해결

### DIFF
--- a/src/main/java/com/likelion13/lucaus_api/service/NotionService.java
+++ b/src/main/java/com/likelion13/lucaus_api/service/NotionService.java
@@ -409,8 +409,8 @@ public class NotionService {
 
 
     // DetailedNotice 데이터를 주기적으로 가져오는 메서드
-//    @Scheduled(cron = "0 0 0 * * *")
-    @Scheduled(cron = "0 * * * * *")
+    @Scheduled(cron = "0 0 0 * * *")
+//    @Scheduled(cron = "0 * * * * *")
     public void fetchDetailedNotices() {
 
         List<DetailedNoticeDto> detailedNotices = fetchNotionDataFromDatabaseId(notionConfig.getDetailedNoticesDbId(), DetailedNoticeDto.class);


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

공지사항 제목이 제목없음으로 올라가고, DB에도 null로 올라오는 것을 확인했습니다.
노션 DB -> mysql 적재시에 필드 값 오류가 있어서 해당 이슈가 발생하고 있었습니다.
필드 수정으로 오류 해결 했습니다!

## 🛠️ PR 유형

어떤 변경 사항이 있나요?
<!--- 해당 사항 체크 후 나머지 항목은 지워주세요 -->

- [ ] 버그 수정


## 📸스크린샷 (선택)
<img width="707" alt="image" src="https://github.com/user-attachments/assets/b4af93e3-48b9-494d-add2-ffebeb073812" />

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
