### PR TITLE
[fix] notionDB ETL 필드 변경

### DIFF
--- a/src/main/java/com/likelion13/lucaus_api/domain/entity/detailedNotices/DetailedNotices.java
+++ b/src/main/java/com/likelion13/lucaus_api/domain/entity/detailedNotices/DetailedNotices.java
@@ -45,6 +45,8 @@ public class DetailedNotices {
         this.photoUrl = photoUrl;
     }
 
+    public void changeuploadDateTime(LocalDateTime uploadDateTime){this.uploadDateTime=uploadDateTime;}
+
 
 
 }

--- a/src/main/java/com/likelion13/lucaus_api/service/notion/NotionService.java
+++ b/src/main/java/com/likelion13/lucaus_api/service/notion/NotionService.java
@@ -105,6 +105,18 @@ public class NotionService {
     }
 
     private ShortNoticeDto mapToShortNoticeDto(JSONObject page) {
+        String uploadDateTimeString = page.optString("created_time");
+
+        LocalDateTime createdTime = null;
+        if (uploadDateTimeString != null && !uploadDateTimeString.isEmpty()) {
+            try {
+                DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+                createdTime = LocalDateTime.parse(uploadDateTimeString, formatter);
+            } catch (Exception e) {
+                logger.error("Failed to parse created_time: {}", uploadDateTimeString, e);
+            }
+        }
+
         JSONObject properties = page.optJSONObject("properties");
 
         JSONObject visibility = properties.optJSONObject("노출 여부");
@@ -120,26 +132,6 @@ public class NotionService {
                         .optString("content");
             }
         }
-
-        LocalDateTime createdTime = null;
-        JSONObject timeObj = properties.optJSONObject("등록 일시");
-
-        if (timeObj != null) {
-            JSONObject dateObj = timeObj.optJSONObject("date");
-            if (dateObj != null) {
-                String startDateStr = dateObj.optString("start");
-
-                if (startDateStr != null && !startDateStr.isEmpty()) {
-                    try {
-                        LocalDate date = LocalDate.parse(startDateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-                        createdTime = date.atStartOfDay();
-                    } catch (Exception e) {
-                        logger.error("Failed to parse 등록 일시: {}", startDateStr, e);
-                    }
-                }
-            }
-        }
-
         String notionId = page.optString("id");
 
         return ShortNoticeDto.builder()
@@ -152,19 +144,31 @@ public class NotionService {
 
 
     private DetailedNoticeDto mapToDetailedNoticeDto(JSONObject page) {
-        String uploadDateTimeString = page.optString("created_time");
+
+        JSONObject properties = page.optJSONObject("properties");
 
         LocalDateTime uploadDateTime = null;
-        if (uploadDateTimeString != null && !uploadDateTimeString.isEmpty()) {
-            try {
-                DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-                uploadDateTime = LocalDateTime.parse(uploadDateTimeString, formatter);
-            } catch (Exception e) {
-                logger.error("Failed to parse created_time: {}", uploadDateTimeString, e);
+        JSONObject timeObj = properties.optJSONObject("등록 일시");
+
+        if (timeObj != null) {
+            JSONObject dateObj = timeObj.optJSONObject("date");
+            if (dateObj != null) {
+                String startDateStr = dateObj.optString("start");
+
+                if (startDateStr != null && !startDateStr.isEmpty()) {
+                    try {
+                        LocalDate date = LocalDate.parse(startDateStr, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                        uploadDateTime = date.atStartOfDay();
+                    } catch (Exception e) {
+                        logger.error("Failed to parse 등록 일시: {}", startDateStr, e);
+                    }
+                }
             }
         }
 
-        JSONObject properties = page.optJSONObject("properties");
+        System.out.println("등록 일시");
+        System.out.println(uploadDateTime);
+
         String category = null;
         if (properties != null) {
             JSONObject categoryObj = properties.optJSONObject("카테고리");
@@ -409,8 +413,8 @@ public class NotionService {
 
 
     // DetailedNotice 데이터를 주기적으로 가져오는 메서드
-    @Scheduled(cron = "0 */10 * * * *")
-//    @Scheduled(cron = "0 * * * * *")
+//    @Scheduled(cron = "0 */10 * * * *")
+    @Scheduled(cron = "0 * * * * *")
     public void fetchDetailedNotices() {
 
         List<DetailedNoticeDto> detailedNotices = fetchNotionDataFromDatabaseId(notionConfig.getDetailedNoticesDbId(), DetailedNoticeDto.class);
@@ -427,6 +431,7 @@ public class NotionService {
                 detailedNoticesEntity.changeContent(detailedNoticeDto.getContent());
                 detailedNoticesEntity.changePhotoUrl(detailedNoticeDto.getPhotoUrl());
                 detailedNoticesEntity.changeNotionPhotoUrl(detailedNoticeDto.getNotionPhotoUrl());
+                detailedNoticesEntity.changeuploadDateTime(detailedNoticeDto.getUploadDateTime());
             } else {
                 detailedNoticesEntity = DetailedNotices.builder()
                         .category(detailedNoticeDto.getCategory())


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

notionDB ETL 필드 변경

## 🛠️ PR 유형

어떤 변경 사항이 있나요?
<!--- 해당 사항 체크 후 나머지 항목은 지워주세요 -->


- [ ] 기능 수정

## 📸스크린샷 (선택)
<img width="412" alt="image" src="https://github.com/user-attachments/assets/be03c64a-a0e8-471e-87a2-310b42e3bc59" />

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

notionDB ETL 필드 변경했습니다.
한줄 안내는 created at 필드를 추가하였고,
총학 공지는 현재 etl 과정에서 등록 시간이 아닌 created_at 필드를 가지고 오고 있어서 수정하였습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
